### PR TITLE
Chore: lerna publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ deploy:
   - provider: script
     skip-cleanup: true
     script:
-      - lerna publish
+      - yarn publish-ci --yes
     on:
       branch: master

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,8 @@
     "publish": {
       "ignoreChanges": [
         "*.md"
-      ]
+      ],
+      "allowBranch": "master"
     }
   },
   "lerna": "2.9.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,12 +1,16 @@
 {
   "command": {
     "publish": {
-      "ignoreChanges": ["*.md"]
+      "ignoreChanges": [
+        "*.md"
+      ]
     }
   },
   "lerna": "2.9.1",
   "npmClient": "yarn",
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/*"
+  ],
   "useWorkspaces": true,
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "precommit": "npm run lint",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "prepush": "npm test",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "publish-ci": "lerna publish --conventional-commits --changelog-preset mol-conventional-changelog"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Add --yes to travis publish so it can work in travis
Make lerna publish to use conventional commits

Lerna publish docs: https://github.com/lerna/lerna/tree/master/commands/publish#readme

To test in your machine: use `yarn publish-ci --skip-npm  --skip-git` so we can avoid publishing to npm and to git