### PR TITLE
chore: 🚜 use npm client when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "prepush": "npm test",
     "test": "lerna run --stream test",
-    "publish-ci": "lerna publish --conventional-commits --changelog-preset mol-conventional-changelog"
+    "publish-ci": "lerna publish --conventional-commits --changelog-preset mol-conventional-changelog --npm-client=npm"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
... This is quite annoying but the publish with yarn fails because it
tries to prompt the user event if lerna provides a version. Not clear
how to solve this in travis env. Found this issue
https://github.com/yarnpkg/yarn/issues/2591 and it seems to be an issue
with the environment. Whaterver the case using npm should fix the
problem. I hope