### PR TITLE
fix: 🐜 do not subscribe to AdLoaded evt twice

### DIFF
--- a/src/adUnit/VpaidAdUnit.js
+++ b/src/adUnit/VpaidAdUnit.js
@@ -65,6 +65,9 @@ const {
   closeLinear
 } = linearEvents;
 
+// NOTE some ads only allow one handler per event and we need to subscribe to the adLoaded to know the creative is loaded.
+const VPAID_EVENTS = EVENTS.filter((event) => event !== adLoaded);
+
 // eslint-disable-next-line id-match
 const _private = Symbol('_private');
 
@@ -309,7 +312,7 @@ class VpaidAdUnit extends VideoAdUnit {
       this.creativeAd = await this[_private].loadCreativePromise;
       const adLoadedPromise = waitFor(this.creativeAd, adLoaded);
 
-      for (const creativeEvt of EVENTS) {
+      for (const creativeEvt of VPAID_EVENTS) {
         this.creativeAd.subscribe(this[_private].handleVpaidEvt.bind(this, creativeEvt), creativeEvt);
       }
 

--- a/src/adUnit/__tests__/VpaidAdUnit.spec.js
+++ b/src/adUnit/__tests__/VpaidAdUnit.spec.js
@@ -740,7 +740,7 @@ describe('VpaidAdUnit', () => {
       adUnit = new VpaidAdUnit(vpaidChain, videoAdContainer);
     });
 
-    for (const vpaidEvt of EVENTS) {
+    for (const vpaidEvt of EVENTS.filter((evt) => evt !== adLoaded)) {
       test(`${vpaidEvt} must be emitted by the ad unit`, async () => {
         const callback = jest.fn();
 


### PR DESCRIPTION
some creatives only allow one handler per event